### PR TITLE
Fix #1: round process_data average to 2 decimal places

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ def process_data(items):
     return {
         "count": len(items),
         "total": total,
-        "average": total / len(items),
+        "average": round(total / len(items), 2),
     }
 
 

--- a/test_app.py
+++ b/test_app.py
@@ -14,6 +14,10 @@ class TestProcessData(unittest.TestCase):
         self.assertEqual(result["total"], 60)
         self.assertEqual(result["average"], 20)
 
+    def test_rounded_average(self):
+        result = process_data([1, 2, 4])
+        self.assertEqual(result["average"], 2.33)
+
 
 class TestFilterItems(unittest.TestCase):
     def test_min_filter(self):


### PR DESCRIPTION
Closes #1

## Changes
- `app.py`: wrap `total / len(items)` in `round(..., 2)` to return a float rounded to 2 decimal places
- `test_app.py`: add `test_rounded_average` using input `[1, 2, 4]` (average 2.3333...) to assert `result["average"] == 2.33`

## Testing
- All 5 tests pass: `test_empty_list`, `test_basic_stats`, `test_rounded_average`, `test_min_filter`, `test_max_filter`
- Run with: `python3 -m unittest discover -v`